### PR TITLE
Log on Android NDK not found

### DIFF
--- a/dinghy-lib/src/android/mod.rs
+++ b/dinghy-lib/src/android/mod.rs
@@ -184,6 +184,7 @@ fn ndk() -> Result<Option<path::PathBuf>> {
             return Ok(Some(sdk.join("ndk-bundle")));
         }
     }
+    debug!("Android NDK not found");
     Ok(None)
 }
 


### PR DESCRIPTION
For #121.
