### PR TITLE
Better error message on rsync exec

### DIFF
--- a/dinghy-lib/src/ssh/device.rs
+++ b/dinghy-lib/src/ssh/device.rs
@@ -109,7 +109,7 @@ impl SshDevice {
                 path_to_str(&to_path.as_ref())?
             ));
         debug!("Running {:?}", command);
-        if !command.status()?.success() {
+        if !command.status().with_context(||format!("failed to run '{:?}'", command))?.success() {
             bail!("Error syncing ssh directory ({:?})", command)
         } else {
             Ok(())


### PR DESCRIPTION
On a system with rsync not installed the error message is a simple
`FilenotFound` witch is a bit hard to debug