### PR TITLE
Fix iOS 9.3

### DIFF
--- a/dinghy-lib/src/ios/device.rs
+++ b/dinghy-lib/src/ios/device.rs
@@ -517,16 +517,14 @@ fn ensure_session(dev: *const am_device) -> Result<Session> {
             bail!("lost pairing")
         };
         mk_result(AMDeviceValidatePairing(dev))?;
-        mk_result(AMDeviceStartSession(dev))?;
-        Ok(Session(dev))
-        // debug!("ensure session 4 ({:x})", rv);
-        // if rv as u32 == 0xe800001d {
-        // Ok(Session(::std::ptr::null()))
-        // } else {
-        // mk_result(rv)?;
-        // Ok(Session(dev))
-        // }
-        //
+        let rv = AMDeviceStartSession(dev);
+        // kAMDSessionActiveError
+        if rv as u32 == 0xe800001d {
+            Ok(Session(::std::ptr::null()))
+        } else {
+            mk_result(rv)?;
+            Ok(Session(dev))
+        }
     }
 }
 


### PR DESCRIPTION
This was originally found in 56644228b77686f9da82be30d0846bbf8dc354c3, I've just uncommented it because it made my setup work:
- Device: iPad mini 1st generation, running iOS 9.3.6
- Host: macOS 10.14.6 Mojave
