### PR TITLE
Dont run tests for `proc-macro` crates

### DIFF
--- a/dinghy-lib/src/compiler.rs
+++ b/dinghy-lib/src/compiler.rs
@@ -9,6 +9,7 @@ use crate::Result;
 use crate::Runnable;
 use cargo::core::compiler as CargoCoreCompiler;
 use cargo::core::compiler::Compilation;
+use cargo::core::compiler::CompileKind;
 pub use cargo::core::compiler::CompileMode;
 use cargo::core::compiler::MessageFormat;
 use cargo::core::resolver::CliFeatures;
@@ -499,6 +500,8 @@ fn to_build(
             _ => compilation
                 .tests
                 .iter()
+                // Filter out proc macro tests
+                .filter(|output| output.unit.kind != CompileKind::Host)
                 .map(|output| {
                     Ok(Runnable {
                         exe: output.path.clone(),

--- a/test-ws/Cargo.lock
+++ b/test-ws/Cargo.lock
@@ -12,3 +12,7 @@ version = "0.1.0"
 dependencies = [
  "dinghy-test",
 ]
+
+[[package]]
+name = "test-proc-macro"
+version = "0.1.0"

--- a/test-ws/Cargo.toml
+++ b/test-ws/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["test-app"]
+members = ["test-app", "test-proc-macro"]

--- a/test-ws/test-proc-macro/Cargo.toml
+++ b/test-ws/test-proc-macro/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "test-proc-macro"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+proc-macro = true


### PR DESCRIPTION
Tests for these are built by `cargo` for the host platform, and hence don't make sense to run in `cargo dinghy` (and will fail horribly if we try).