### PR TITLE
tests are actually runnable on host platform

### DIFF
--- a/dinghy-lib/src/compiler.rs
+++ b/dinghy-lib/src/compiler.rs
@@ -501,7 +501,7 @@ fn to_build(
                 .tests
                 .iter()
                 // Filter out proc macro tests
-                .filter(|output| output.unit.kind != CompileKind::Host)
+                .filter(|output| platform.is_host() || output.unit.kind != CompileKind::Host)
                 .map(|output| {
                     Ok(Runnable {
                         exe: output.path.clone(),


### PR DESCRIPTION
Follow-up for #144, ping @madsmtm .

So, the CI was not made to run on PRs (for ages, since migration from travis).

This prevented us from noticing a nasty side-effect that was actually detected by CI. Then when main failed, I guessed wrongly it was an external cause, like the rust bump a few days before, so did not rush for a fix... Anyway the CI script is running now.

WDYT ?