### PR TITLE
Fix iOS simulator tests with lldb 13

### DIFF
--- a/dinghy-lib/src/ios/device.rs
+++ b/dinghy-lib/src/ios/device.rs
@@ -749,7 +749,7 @@ fn launch_app(dev: &IosSimDevice, app_args: &[&str], _envs: &[&str]) -> Result<(
     println!("{}", test_contents);
 
     let output: String = String::from_utf8_lossy(&output.stdout).to_string();
-    debug!("LLDB OUTPUT: {}", output);
+    debug!("lldb script: \n{}", output);
     // The stdout from lldb is something like:
     //
     // (lldb) attach 34163
@@ -762,18 +762,17 @@ fn launch_app(dev: &IosSimDevice, app_args: &[&str], _envs: &[&str]) -> Result<(
     //     0x1019cd003 <+3>: movq   %rsp, %rbp
     //     0x1019cd006 <+6>: andq   $-0x10, %rsp
     // Target 0: (Dinghy) stopped.
-    //
     // Executable module set to .....
     // Architecture set to: x86_64h-apple-ios-.
     // (lldb) continue
     // Process 34163 resuming
     // Process 34163 exited with status = 101 (0x00000065)
-    //
     // (lldb) quit
     //
     // We need the "exit with status" line which is the 3rd from the last
-    let lines: Vec<&str> = output.lines().rev().collect();
-    let exit_status_line = lines.get(2);
+    let lines: Vec<&str> = output.lines().filter(|line| line.trim().len() > 0).rev().collect();
+    let exit_status_line = lines.get(1);
+    debug!("exit status line: {:?}", exit_status_line);
     if let Some(exit_status_line) = exit_status_line {
         let words: Vec<&str> = exit_status_line.split_whitespace().rev().collect();
         if let Some(exit_status) = words.get(1) {


### PR DESCRIPTION
I went to write some iOS unit tests today and found that the output for `lldb -s <script>` has removed blank lines in the output.

It used to be something like:
```
(lldb) command source -s 0 '../lldb-script'
Executing commands in '/Users/simlay/projects/rust-ios/dinghy/lldb-script'.
(lldb) attach 9325
Process 9325 stopped
* thread #1, stop reason = signal SIGSTOP
    frame #0: 0x0000000202f4a455 dyld`invocation function for block in dyld3::MachOFile::forEachSegment(void (dyld3::MachOFile::SegmentInfo const&, bool&) block_pointer) const + 549
dyld`invocation function for block in dyld3::MachOFile::forEachSegment(void (dyld3::MachOFile::SegmentInfo const&, bool&) block_pointer) const:
->  0x202f4a455 <+549>: callq  *0x10(%rdi)
    0x202f4a458 <+552>: movq   0x28(%r14), %rax
    0x202f4a45c <+556>: movq   0x8(%rax), %rax
    0x202f4a460 <+560>: incl   0x18(%rax)
Target 0: (Dinghy) stopped.

Executable module set to "/Users/simlay/Library/Developer/CoreSimulator/Devices/2E203D7E-6774-4160-ACEC-AC553A01B697/data/Containers/Bundle/Application/F50E1504-ECCD-45B4-A507-04BEE1E016E2/Dinghy.app/Dinghy".
Architecture set to: x86_64-apple-ios-simulator.
(lldb) continue
Process 9325 resuming
Process 9325 exited with status = 101 (0x00000065)

(lldb) quit
```

And now the ending portion which has the `exited with status` it is something like:
```
(lldb) continue
Process 9325 resuming
Process 9325 exited with status = 101 (0x00000065)
(lldb) quit
```

I checked the llvm 13 release notes (because xcode 13 ships with llvm 13 I think) and couldn't find anything about this. Probably because changes to the stdout of a lldb script aren't meant for programmatic use. Long term I think using something like the [`lldb` crate](https://github.com/endoli/lldb.rs).

Anyway, I changed this to work with both outputs by removing blank lines.