### PR TITLE
Initial stuff for aarch64 ios simulator support

### DIFF
--- a/dinghy-lib/src/ios/device.rs
+++ b/dinghy-lib/src/ios/device.rs
@@ -314,7 +314,10 @@ impl DeviceCompatibility for IosDevice {
 
 impl DeviceCompatibility for IosSimDevice {
     fn is_compatible_with_ios_platform(&self, platform: &IosPlatform) -> bool {
-        platform.sim && platform.toolchain.rustc_triple == "x86_64-apple-ios"
+        platform.sim && (
+            platform.toolchain.rustc_triple == "x86_64-apple-ios" ||
+            platform.toolchain.rustc_triple == "aarch64-apple-ios-sim"
+        )
     }
 }
 

--- a/dinghy-lib/src/ios/mod.rs
+++ b/dinghy-lib/src/ios/mod.rs
@@ -118,7 +118,7 @@ impl PlatformManager for IosManager {
     }
 
     fn platforms(&self) -> Result<Vec<Box<dyn Platform>>> {
-        ["armv7", "armv7s", "aarch64", "aarch64-sim", "i386", "x86_64"]
+        ["armv7", "armv7s", "aarch64", "i386", "x86_64", "aarch64-sim"]
             .iter()
             .map(|arch| {
                 let id = format!("auto-ios-{}", arch);

--- a/dinghy-lib/src/ios/mod.rs
+++ b/dinghy-lib/src/ios/mod.rs
@@ -118,11 +118,16 @@ impl PlatformManager for IosManager {
     }
 
     fn platforms(&self) -> Result<Vec<Box<dyn Platform>>> {
-        ["armv7", "armv7s", "aarch64", "i386", "x86_64"]
+        ["armv7", "armv7s", "aarch64", "aarch64-sim", "i386", "x86_64"]
             .iter()
             .map(|arch| {
                 let id = format!("auto-ios-{}", arch);
-                let rustc_triple = format!("{}-apple-ios", arch);
+                let rustc_triple =
+                if *arch != "aarch64-sim" {
+                    format!("{}-apple-ios", arch)
+                } else {
+                    format!("aarch64-apple-ios-sim")
+                };
                 IosPlatform::new(
                     id,
                     &rustc_triple,

--- a/dinghy-lib/src/ios/platform.rs
+++ b/dinghy-lib/src/ios/platform.rs
@@ -37,7 +37,7 @@ impl IosPlatform {
     ) -> Result<Box<dyn Platform>> {
         Ok(Box::new(IosPlatform {
             id,
-            sim: rustc_triple.contains("86"),
+            sim: rustc_triple.contains("86") || rustc_triple.contains("sim"),
             toolchain: Toolchain {
                 rustc_triple: rustc_triple.to_string(),
             },


### PR DESCRIPTION
Closes #147.

I don't think we can test this in CI. I've tested it on my m1 and it works as expected.

This change results in `cargo dinghy all-devices` shows:
```
$ cargo dinghy all-devices
List of available devices for all platforms:
Host: [host]
IosSimDevice { "id": "09EA58D0-0385-4151-AEFB-EBD5D40BA04B", "name": iPhone 8, "os": com.apple.CoreSimulator.SimRuntime.iOS-15-4 }: [auto-ios-aarch64-sim, auto-ios-x86_64]
IosSimDevice { "id": "DF2E630F-5872-4718-9F1C-B20C188013F5", "name": iPhone 8 Plus, "os": com.apple.CoreSimulator.SimRuntime.iOS-15-4 }: [auto-ios-aarch64-sim, auto-ios-x86_64]
```

Though, on non-m1 apple products it will still display `auto-ios-aarch64-sim` and if ran, I assume it would fail with a weird error but I've not tested that. Should I make non aarch64 devices not list the `auto-ios-aarch64-sim`?

As a note why this is useful I tested this with [`hyperfine`](https://github.com/sharkdp/hyperfine) in the `test-ws` CI (that's pre-compiled):
```
$ hyperfine '../target/debug/cargo-dinghy --platform auto-ios-aarch64-sim test pass'
Benchmark 1: ../target/debug/cargo-dinghy --platform auto-ios-aarch64-sim test pass
  Time (mean ± σ):      2.238 s ±  0.034 s    [User: 0.324 s, System: 0.190 s]
  Range (min … max):    2.209 s …  2.333 s    10 runs

$ hyperfine '../target/debug/cargo-dinghy --platform auto-ios-x86_64 test pass'
Benchmark 1: ../target/debug/cargo-dinghy --platform auto-ios-x86_64 test pass
  Time (mean ± σ):      4.030 s ±  0.197 s    [User: 1.279 s, System: 0.667 s]
  Range (min … max):    3.858 s …  4.542 s    10 runs
```

In this case, I think this ~2 second difference might be due to macOS or the iOS simulator starting [Rosetta 2](https://en.wikipedia.org/wiki/Rosetta_(software)#Rosetta_2) to run the x86 program but being able to test and benchmark on the architecture a program is running is important.