### PR TITLE
Fix iOS bundle to make app use the full screen

### DIFF
--- a/dinghy-lib/src/ios/xcode.rs
+++ b/dinghy-lib/src/ios/xcode.rs
@@ -28,6 +28,8 @@ pub fn add_plist_to_app(bundle: &BuildBundle, arch: &str, app_bundle_id: &str) -
     writeln!(plist, "<string>{}</string>", arch)?;
     writeln!(plist, "<key>CFBundleShortVersionString</key>")?;
     writeln!(plist, "<string>{}</string>", arch)?;
+    writeln!(plist, "<key>UILaunchStoryboardName</key>")?;
+    writeln!(plist, "<string></string>")?;
     writeln!(plist, r#"</dict></plist>"#)?;
     /*
     let app_name = app_bundle_id.split(".").last().unwrap();


### PR DESCRIPTION
This is the same fix from https://github.com/burtonageo/cargo-bundle/pull/108 to fix https://github.com/burtonageo/cargo-bundle/issues/91.