### PR TITLE
Use package name instead of runnable id for dir on target

### DIFF
--- a/cargo-dinghy/src/main.rs
+++ b/cargo-dinghy/src/main.rs
@@ -120,6 +120,7 @@ fn run_command(cli: DinghyCli) -> Result<()> {
                     dynamic_libraries: vec![],
                     runnable: Runnable {
                         id: exe_id,
+                        package_name: std::env::var("CARGO_PKG_NAME")?,
                         exe: PathBuf::from(exe).canonicalize()?,
                         // cargo launches the runner inside the dir of the crate
                         source: PathBuf::from(".").canonicalize()?,

--- a/dinghy-lib/src/device.rs
+++ b/dinghy-lib/src/device.rs
@@ -32,8 +32,8 @@ pub fn make_remote_app_with_name(
 
     let root_dir = build.target_path.join("dinghy");
     let bundle_path = match bundle_name {
-        Some(name) => root_dir.join(&build.runnable.id).join(name),
-        None => root_dir.join(&build.runnable.id),
+        Some(name) => root_dir.join(&build.runnable.package_name).join(name),
+        None => root_dir.join(&build.runnable.package_name),
     };
     let bundle_libs_path = root_dir.join("overlay");
     let bundle_target_path = &bundle_path;

--- a/dinghy-lib/src/lib.rs
+++ b/dinghy-lib/src/lib.rs
@@ -291,6 +291,7 @@ impl BuildBundle {
 #[derive(Clone, Debug, Default)]
 pub struct Runnable {
     pub id: String,
+    pub package_name: String,
     pub exe: path::PathBuf,
     pub source: path::PathBuf,
 }


### PR DESCRIPTION
This means means multiple runnables from the same package (ie
integration tests) will live in the same directory on the target device
and this directory will be stable and will not contain a build hash.

This is way better for disk usage especially when lots for tests
resources need to be copied (as those will not be duplicated on the
target device). This should also improve the first execution time on ssh
devices when there are multiple integration tests in the package as the
resources will need to only be copied once then rsync will do some magic