### PR TITLE
Logging overhaul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +202,7 @@ dependencies = [
  "anyhow",
  "atty",
  "cargo_metadata",
+ "colored",
  "core-foundation",
  "core-foundation-sys",
  "dinghy-build",
@@ -200,6 +212,7 @@ dependencies = [
  "ignore",
  "itertools",
  "json",
+ "lazy_static",
  "libc",
  "log",
  "plist",

--- a/dinghy-lib/Cargo.toml
+++ b/dinghy-lib/Cargo.toml
@@ -35,6 +35,8 @@ which = "4.0"
 shellexpand="2"
 semver = "1"
 cargo_metadata = "0.14.2"
+colored = "2.0.0"
+lazy_static = "1.4.0"
 dyn-clone = "1.0.8"
 
 [dev-dependencies]

--- a/dinghy-lib/src/android/mod.rs
+++ b/dinghy-lib/src/android/mod.rs
@@ -6,6 +6,7 @@ use std::{env, fs, path, process};
 pub use self::device::AndroidDevice;
 
 use crate::android::platform::AndroidPlatform;
+use crate::utils::LogCommandExt;
 use anyhow::{anyhow, bail, Context};
 use log::debug;
 
@@ -18,7 +19,10 @@ pub struct AndroidManager {
 
 impl PlatformManager for AndroidManager {
     fn devices(&self) -> Result<Vec<Box<dyn Device>>> {
-        let result = process::Command::new(&self.adb).arg("devices").output()?;
+        let result = process::Command::new(&self.adb)
+            .arg("devices")
+            .log_invocation(3)
+            .output()?;
         let mut devices = vec![];
         let device_regex = ::regex::Regex::new(r#"^(\S+)\tdevice\r?$"#)?;
         for line in String::from_utf8(result.stdout)?.split("\n").skip(1) {
@@ -213,6 +217,7 @@ fn adb() -> Result<path::PathBuf> {
             .arg("--version")
             .stdout(process::Stdio::null())
             .stderr(process::Stdio::null())
+            .log_invocation(3)
             .status()
         {
             Ok(_) => true,

--- a/dinghy-lib/src/host/platform.rs
+++ b/dinghy-lib/src/host/platform.rs
@@ -2,6 +2,7 @@ use crate::config::PlatformConfiguration;
 use crate::overlay::Overlayer;
 use crate::platform;
 use crate::project::Project;
+use crate::utils::LogCommandExt;
 use crate::Build;
 use crate::Device;
 use crate::Platform;
@@ -42,8 +43,8 @@ impl Platform for HostPlatform {
         let triple = std::process::Command::new("rustc")
             .arg("-vV")
             .stdout(Stdio::piped())
-            .spawn()?
-            .wait_with_output()?
+            .log_invocation(3)
+            .output()?
             .stdout
             .lines()
             .find_map(|line| {

--- a/dinghy-lib/src/platform/mod.rs
+++ b/dinghy-lib/src/platform/mod.rs
@@ -1,4 +1,4 @@
-use crate::utils::file_name_as_str;
+use crate::utils::{file_name_as_str, LogCommandExt};
 use crate::Result;
 use crate::Runnable;
 use std::fs;
@@ -25,7 +25,7 @@ pub fn strip_runnable(runnable: &Runnable, mut command: Command) -> Result<Runna
     let command = command.arg(&stripped_runnable.exe);
     debug!("Running command {:?}", command);
 
-    let output = command.output()?;
+    let output = command.log_invocation(2).output()?;
     if !output.status.success() {
         bail!(
             "Error while stripping {}\nError: {}",

--- a/dinghy-lib/src/script/device.rs
+++ b/dinghy-lib/src/script/device.rs
@@ -1,4 +1,5 @@
 use crate::config::ScriptDeviceConfiguration;
+use crate::utils::LogCommandExt;
 use crate::*;
 use anyhow::bail;
 use std::{fmt, fs, process};
@@ -80,6 +81,7 @@ impl Device for ScriptDevice {
                     })
                     .collect::<Result<Vec<_>>>()?,
             )
+            .log_invocation(1)
             .status()?;
         if !status.success() {
             bail!("Test failed")


### PR DESCRIPTION
This builds upon #167 and ~doesn't cover ios as #168 is not merged yet~ UPDATED with ios support

This changes  how logs are handled in dinghy and add the new concept of "user facing logs", that are now controled by the `-v` arguments on the commandline.

Regular rust logging is still available via env logger using the `DINGHY_LOG` environment variable. (Still usefull when debugging dinghy, not so much for regular users)

The idea is to emulate the way cargo works and have a coherent experience for the user.

Here is a sample result without passing any verbose flag

```
cargo dinghy -d android  run
   Targeting platform android-aarch64-ndk16b and device 'e3cca7b9'
   Compiling hello v0.1.0 (/tmp/hello)
    Finished dev [unoptimized + debuginfo] target(s) in 0.48s
     Running `/home/fredszaq/.cargo/bin/cargo-dinghy -p android-aarch64-ndk16b -d e3cca7b9 runner -- target/aarch64-linux-android/debug/hello`
  Installing hello to e3cca7b9
     Running hello on e3cca7b9
Hello, world!
FORWARD_RESULT_TO_DINGHY_BECAUSE_ADB_DOES_NOT=0
```

and with full verbosity for dinghy

```
cargo dinghy -vvvv -d android  run
     Running "/usr/bin/adb" "devices"
     Running "/usr/bin/adb" "-s" "e3cca7b9" "shell" "getprop" "ro.product.cpu.abilist"
   Targeting platform android-aarch64-ndk16b and device e3cca7b9
     Running "/home/fredszaq/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/cargo" "run"
    Finished dev [unoptimized + debuginfo] target(s) in 0.00s
     Running `/home/fredszaq/.cargo/bin/cargo-dinghy -p android-aarch64-ndk16b -v -v -v -v -d e3cca7b9 runner -- target/aarch64-linux-android/debug/hello`
     Running "/usr/bin/adb" "devices"
     Running "/usr/bin/adb" "-s" "e3cca7b9" "shell" "getprop" "ro.product.cpu.abilist"
  Installing hello to e3cca7b9
     Running "/usr/bin/adb" "-s" "e3cca7b9" "shell" "mkdir" "-p" "/data/local/tmp/dinghy"
     Running "/usr/bin/adb" "-s" "e3cca7b9" "push" "--sync" "/tmp/hello/target/dinghy/hello" "/data/local/tmp/dinghy"
     Running "/usr/bin/adb" "-s" "e3cca7b9" "push" "--sync" "/tmp/hello/target/dinghy/overlay" "/data/local/tmp/dinghy"
     Running "/usr/bin/adb" "-s" "e3cca7b9" "shell" "chmod" "755" "/data/local/tmp/dinghy/hello/_dinghy_hello"
     Running "/usr/bin/adb" "-s" "e3cca7b9" "shell" "cd \'/data/local/tmp/dinghy/hello\';  DINGHY=1 RUST_BACKTRACE=1 LD_LIBRARY_PATH=\"/data/local/tmp/dinghy/overlay:$LD_LIBRARY_PATH\" /data/local/tmp/dinghy/hello/_dinghy_hello  ; echo FORWARD_RESULT_TO_DINGHY_BECAUSE_ADB_DOES_NOT=$?"
Hello, world!
FORWARD_RESULT_TO_DINGHY_BECAUSE_ADB_DOES_NOT=0
```

note that the categories for dinghy are blue (in contrast to the green ones of cargo) and respect the `CLICOLOR`, `CLICOLOR_FORCE` and `NO_COLOR` environment variables (using colored)