### PR TITLE
Mention ios-deploy in docu

### DIFF
--- a/docs/ios.md
+++ b/docs/ios.md
@@ -14,7 +14,7 @@ cargo install cargo-dinghy --force
 
 ### Additional Requirements
 
-In order to deploy to iOS one needs to install [ios-deploy](https://github.com/ios-control/ios-deploy). For example with:
+In order to deploy to iOS devices one needs to install [ios-deploy](https://github.com/ios-control/ios-deploy). For example with:
 `brew install ios-deploy`
 
 ### iOS phone

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -12,6 +12,11 @@ cargo install cargo-dinghy
 cargo install cargo-dinghy --force
 ```
 
+### Additional Requirements
+
+In order to deploy to iOS one needs to install [ios-deploy](https://github.com/ios-control/ios-deploy). For example with:
+`brew install ios-deploy`
+
 ### iOS phone
 
 On iOS, things are made complicated by the fact that there is no way to run a


### PR DESCRIPTION
Since #168 ios-deploy is needed, thus this should be mentioned in the docu.