### PR TITLE
make RUST_BACKTRACE overwritable by --env

### DIFF
--- a/dinghy-lib/src/android/device.rs
+++ b/dinghy-lib/src/android/device.rs
@@ -235,7 +235,7 @@ impl Device for AndroidDevice {
             .collect();
         let (build_bundle, remote_bundle) = self.install_app(&project, &build)?;
         let command = format!(
-                "cd '{}'; {} DINGHY=1 RUST_BACKTRACE=1 LD_LIBRARY_PATH=\"{}:$LD_LIBRARY_PATH\" {} {} ; echo FORWARD_RESULT_TO_DINGHY_BECAUSE_ADB_DOES_NOT=$?",
+                "cd '{}'; RUST_BACKTRACE=1 {} DINGHY=1 LD_LIBRARY_PATH=\"{}:$LD_LIBRARY_PATH\" {} {} ; echo FORWARD_RESULT_TO_DINGHY_BECAUSE_ADB_DOES_NOT=$?",
                 path_to_str(&remote_bundle.bundle_dir)?,
                 envs.join(" "),
                 path_to_str(&remote_bundle.lib_dir)?,

--- a/dinghy-lib/src/ssh/device.rs
+++ b/dinghy-lib/src/ssh/device.rs
@@ -228,7 +228,7 @@ impl Device for SshDevice {
         let (build_bundle, remote_bundle) = self.install_app(&project, &build)?;
         log::debug!("Installed {:?}", build.runnable.id);
         let command = format!(
-            "cd '{}' ; {} RUST_BACKTRACE=1 DINGHY=1 LD_LIBRARY_PATH=\"{}:$LD_LIBRARY_PATH\" {} {}",
+            "cd '{}' ; RUST_BACKTRACE=1 {} DINGHY=1 LD_LIBRARY_PATH=\"{}:$LD_LIBRARY_PATH\" {} {}",
             path_to_str(&remote_bundle.bundle_dir)?,
             envs.join(" "),
             path_to_str(&remote_bundle.lib_dir)?,


### PR DESCRIPTION
Sometimes you want to be able to run with `--env RUST_BACKTRACE=full` and this is not possible with `dinghy` (which sets it to `1`). This patch makes RUST_BACKTRACE overwritable by `--env`.