### PR TITLE
Test on macOS-13 (x86) and macOS-14 (arm)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,10 @@ jobs:
       run: ./.travis.sh
 
   macos:
-    runs-on: macOS-latest
+    strategy:
+      matrix:
+        os: [ macOS-13, macOS-14 ]
+    runs-on: ${{matrix.os}}
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
[Github now has m1 runners](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/). Using macOS-14 will exclusively run on M1s while macOS-13 will still be on intel.