### PR TITLE
android: fix SDK detection on mac.

### DIFF
--- a/dinghy-lib/src/android/mod.rs
+++ b/dinghy-lib/src/android/mod.rs
@@ -168,7 +168,7 @@ fn probable_sdk_locs() -> Result<Vec<path::PathBuf>> {
         }
     }
     if let Ok(home) = env::var("HOME") {
-        let mac = path::Path::new(&home).join("/Library/Android/sdk");
+        let mac = path::Path::new(&home).join("Library/Android/sdk");
         if mac.is_dir() {
             v.push(mac);
         }


### PR DESCRIPTION
According the Path::join's docs, if `path` is absolute, it replaces the
current path, which clearly wasn't the intention in the existing code.
