### PR TITLE
Use matrix in CI for third tier apple simulators

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,18 @@ jobs:
       #    - name: cargo test
       #      run: cargo test --all
 
+  apple-3rd-tier:
+    strategy:
+      matrix:
+        os: [ macOS-13, macOS-14 ]
+        sim: [ tvOS, watchOS ]
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: build and test
+      run: ./.travis.apple-third-tier.sh ${{matrix.sim}}
+
   linux-musl:
     runs-on: ubuntu-latest
     steps:

--- a/.travis.apple-third-tier.sh
+++ b/.travis.apple-third-tier.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -e
+set -x
+
+SIM_TARGET=$1
+
+title() {
+    set +x
+    echo -e '\n\033[1;33m '$@' \033[0m\n'
+    set -x
+}
+if [ -z "$CARGO_DINGHY" ]
+then
+    title "••• build cargo-dinghy •••"
+    cargo build -p cargo-dinghy
+    CARGO_DINGHY="`pwd`/target/debug/cargo-dinghy -vv"
+fi
+echo RUST_VERSION: ${RUST_VERSION:=1.70.0}
+
+rustup toolchain add $RUST_VERSION
+export RUSTUP_TOOLCHAIN=$RUST_VERSION
+rustup toolchain add nightly --component rust-src;
+
+tests_sequence_unstable_target() {
+    # There's something odd with using the .cargo/config runner attribute and
+    # workspaces when the runner uses `cargo run --manifest-path ../Cargo.toml
+    # --bin cargo-dinghy ...`
+    title "testing from project directory for rust target $1 on device $2"
+    title "testing from workspace directory"
+    ( \
+        cd test-ws \
+        && cargo clean \
+        && $CARGO_DINGHY   -d $1 -p $2 +nightly test -Zbuild-std pass \
+        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -Zbuild-std fails \
+        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -Zbuild-std \
+    )
+
+    title "testing from project directory"
+    ( \
+        cd test-ws/test-app \
+        && cargo clean \
+        && $CARGO_DINGHY   -d $1 -p $2 +nightly test -Zbuild-std pass \
+        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -Zbuild-std fails \
+        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -Zbuild-std \
+    )
+
+    title "test from workspace directory with project filter"
+    ( \
+        cd test-ws \
+        && cargo clean \
+        && $CARGO_DINGHY   -d $1 -p $2 +nightly test -p test-app -Zbuild-std pass \
+        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -p test-app -Zbuild-std fails \
+        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -p test-app -Zbuild-std \
+    )
+}
+
+if [ $SIM_TARGET = tvOS ]
+then
+     title "••••• Darwin: tvos simulator tests •••••"
+     title "boot a simulator"
+
+     # *-apple-{tvos,watchos}[-sim] require `-Zbuild-std`
+     TVOS_RUNTIME_ID=$(xcrun simctl list runtimes | grep tvOS | cut -d ' ' -f 7 | tail -1)
+     export TV_SIM_ID=$(xcrun simctl create My-4ktv com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-4K $TVOS_RUNTIME_ID)
+
+     xcrun simctl boot $TV_SIM_ID
+     if [ "$(uname -m)" = "arm64" ]; then
+         tests_sequence_unstable_target ${TV_SIM_ID} auto-tvos-aarch64-sim
+     else
+         # The x86 tvOS simulator tripple does not end in -sim.
+         tests_sequence_unstable_target ${TV_SIM_ID} auto-tvos-x86_64
+     fi
+     xcrun simctl delete $TV_SIM_ID
+fi
+
+if [ $SIM_TARGET = watchOS ]
+then
+     title "••••• Darwin: watchvos simulator tests •••••"
+     title "boot a simulator"
+     WATCHOS_RUNTIME_ID=$(xcrun simctl list runtimes | grep watchOS | cut -d ' ' -f 7 | tail -1)
+     export WATCHOS_SIM_ID=$(xcrun simctl create My-apple-watch com.apple.CoreSimulator.SimDeviceType.Apple-Watch-SE-44mm-2nd-generation $WATCHOS_RUNTIME_ID)
+
+     xcrun simctl boot $WATCHOS_SIM_ID
+     if [ "$(uname -m)" = "arm64" ]; then
+         tests_sequence_unstable_target ${WATCHOS_SIM_ID} auto-watchos-aarch64-sim
+     else
+         tests_sequence_unstable_target ${WATCHOS_SIM_ID} auto-watchos-x86_64-sim
+     fi
+     xcrun simctl delete $WATCHOS_SIM_ID
+
+fi
+
+# This depends on https://github.com/sonos/dinghy/pull/223
+if [ $SIM_TARGET = visionOS ]
+then
+     if [ "$(uname -m)" = "arm64" ]; then
+         title "••••• Darwin: visionOS simulator tests •••••"
+         title "boot a simulator"
+         xcrun simctl list devicetypes vision
+         VISIONOS_DEVICE_TYPE=$(xcrun simctl list devicetypes vision -j | jq -r '.devicetypes[0].identifier')
+         VISIONOS_RUNTIME_ID=$(xcrun simctl list runtimes | grep visionOS | cut -d ' ' -f 7 | tail -1)
+         export VISIONOS_SIM_ID=$(xcrun simctl create My-apple-vision-pro $VISIONOS_DEVICE_TYPE $VISIONOS_RUNTIME_ID)
+
+         xcrun simctl boot $VISIONOS_SIM_ID
+         tests_sequence_unstable_target ${VISIONOS_SIM_ID} auto-visionos-aarch64-sim
+         xcrun simctl delete $VISIONOS_SIM_ID
+     fi
+fi
+rustup default stable

--- a/.travis.sh
+++ b/.travis.sh
@@ -89,39 +89,6 @@ tests_sequence_aarch64_ios_sim() {
     )
 }
 
-tests_sequence_unstable_target() {
-    # There's something odd with using the .cargo/config runner attribute and
-    # workspaces when the runner uses `cargo run --manifest-path ../Cargo.toml
-    # --bin cargo-dinghy ...`
-    title "testing from project directory for rust target $1 on device $2"
-    title "testing from workspace directory"
-    ( \
-        cd test-ws \
-        && cargo clean \
-        && $CARGO_DINGHY   -d $1 -p $2 +nightly test -Zbuild-std pass \
-        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -Zbuild-std fails \
-        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -Zbuild-std \
-    )
-
-    title "testing from project directory"
-    ( \
-        cd test-ws/test-app \
-        && cargo clean \
-        && $CARGO_DINGHY   -d $1 -p $2 +nightly test -Zbuild-std pass \
-        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -Zbuild-std fails \
-        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -Zbuild-std \
-    )
-
-    title "test from workspace directory with project filter"
-    ( \
-        cd test-ws \
-        && cargo clean \
-        && $CARGO_DINGHY   -d $1 -p $2 +nightly test -p test-app -Zbuild-std pass \
-        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -p test-app -Zbuild-std fails \
-        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -p test-app -Zbuild-std \
-    )
-}
-
 
 if [ `uname` = Darwin ]
 then
@@ -157,37 +124,6 @@ then
         rustup target add aarch64-apple-ios
         tests_sequence $device
     fi
-
-     title "••••• Darwin: tvos simulator tests •••••"
-     title "boot a simulator"
-
-     # *-apple-{tvos,watchos}[-sim] require `-Zbuild-std`
-     rustup toolchain add nightly --component rust-src;
-     TVOS_RUNTIME_ID=$(xcrun simctl list runtimes | grep tvOS | cut -d ' ' -f 7 | tail -1)
-     export TV_SIM_ID=$(xcrun simctl create My-4ktv com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-3rd-generation-4K $TVOS_RUNTIME_ID)
-
-     xcrun simctl boot $TV_SIM_ID
-     if [ "$(uname -m)" = "arm64" ]; then
-         tests_sequence_unstable_target ${TV_SIM_ID} auto-tvos-aarch64-sim
-     else
-         # The x86 tvOS simulator tripple does not end in -sim.
-         tests_sequence_unstable_target ${TV_SIM_ID} auto-tvos-x86_64
-     fi
-     xcrun simctl delete $TV_SIM_ID
-
-     title "••••• Darwin: watchvos simulator tests •••••"
-     title "boot a simulator"
-     WATCHOS_RUNTIME_ID=$(xcrun simctl list runtimes | grep watchOS | cut -d ' ' -f 7 | tail -1)
-     export WATCHOS_SIM_ID=$(xcrun simctl create My-apple-watch com.apple.CoreSimulator.SimDeviceType.Apple-Watch-SE-44mm-2nd-generation $WATCHOS_RUNTIME_ID)
-
-     xcrun simctl boot $WATCHOS_SIM_ID
-     if [ "$(uname -m)" = "arm64" ]; then
-         tests_sequence_unstable_target ${WATCHOS_SIM_ID} auto-watchos-aarch64-sim
-     else
-         tests_sequence_unstable_target ${WATCHOS_SIM_ID} auto-watchos-x86_64-sim
-     fi
-     xcrun simctl delete $WATCHOS_SIM_ID
-     rustup default stable
 else
     if [ -n "$ANDROID_SDK_ROOT" ]
     then


### PR DESCRIPTION
Over in https://github.com/sonos/dinghy/pull/223#discussion_r1558279214, it was suggested to move some of the apple simulator targets to be in a github action matrix. 