### PR TITLE
add `skip_source_copy` flag

### DIFF
--- a/cargo-dinghy/src/main.rs
+++ b/cargo-dinghy/src/main.rs
@@ -178,6 +178,7 @@ fn run_command(cli: DinghyCli) -> Result<()> {
                         exe: PathBuf::from(exe).canonicalize()?,
                         // cargo launches the runner inside the dir of the crate
                         source: PathBuf::from(".").canonicalize()?,
+                        skip_source_copy: conf.skip_source_copy,
                     },
                     target_path: project.metadata.target_directory.clone().into(),
                     files_in_run_args,
@@ -369,6 +370,7 @@ fn run_command(cli: DinghyCli) -> Result<()> {
                         package_name: "".to_string(),
                         exe: stripped_lib_file.to_path_buf().into(),
                         source: Default::default(),
+                        skip_source_copy: conf.skip_source_copy,
                     },
                     target_path: Default::default(),
                     files_in_run_args: vec![],

--- a/dinghy-lib/src/apple/xcode.rs
+++ b/dinghy-lib/src/apple/xcode.rs
@@ -120,7 +120,7 @@ pub fn look_for_signature_settings(device_id: &str) -> Result<Vec<SignatureSetti
     let mut settings = vec![];
     let home = dirs::home_dir().expect("can't get HOME dir");
     let profiles_dir = [
-        "Library/MobileDevice/Provisioning Profiles", 
+        "Library/MobileDevice/Provisioning Profiles",
         "Library/Developer/Xcode/UserData/Provisioning Profiles", // xcode 16 and above
     ];
     for file in profiles_dir

--- a/dinghy-lib/src/config.rs
+++ b/dinghy-lib/src/config.rs
@@ -1,11 +1,10 @@
 use itertools::Itertools;
 use serde::de;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::io::Read;
 use std::result;
 use std::{collections, fs, path};
-//use walkdir::WalkDir;
-use serde::{Deserialize, Serialize};
 
 use crate::errors::*;
 
@@ -85,6 +84,7 @@ pub struct Configuration {
     pub ssh_devices: collections::BTreeMap<String, SshDeviceConfiguration>,
     pub script_devices: collections::BTreeMap<String, ScriptDeviceConfiguration>,
     pub test_data: Vec<TestData>,
+    pub skip_source_copy: bool,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
@@ -93,6 +93,7 @@ struct ConfigurationFileContent {
     pub ssh_devices: Option<collections::BTreeMap<String, SshDeviceConfiguration>>,
     pub script_devices: Option<collections::BTreeMap<String, ScriptDeviceConfiguration>>,
     pub test_data: Option<collections::BTreeMap<String, TestDataConfiguration>>,
+    pub skip_source_copy: Option<bool>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
@@ -176,6 +177,9 @@ impl Configuration {
                 copy_git_ignored: source.copy_git_ignored,
             })
         }
+        if let Some(skip_source_copy) = other.skip_source_copy {
+            self.skip_source_copy = skip_source_copy
+        }
         Ok(())
     }
 }
@@ -217,6 +221,9 @@ pub fn dinghy_config<P: AsRef<path::Path>>(dir: P) -> Result<Configuration> {
             log::trace!("No configuration found at {:?}", file);
         }
     }
+
+    log::debug!("Configuration: {:#?}", conf);
+
     Ok(conf)
 }
 

--- a/dinghy-lib/src/device.rs
+++ b/dinghy-lib/src/device.rs
@@ -108,17 +108,22 @@ pub fn make_remote_app_with_name(
         }
     }
 
-    debug!(
-        "Copying src {} to bundle {}",
-        build.runnable.source.display(),
-        bundle_path.display()
-    );
-    project::rec_copy_excl(
-        &build.runnable.source,
-        &bundle_path,
-        false,
-        &[build.runnable.source.join("target")],
-    )?;
+    if !build.runnable.skip_source_copy {
+        debug!(
+            "Copying src {} to bundle {}",
+            build.runnable.source.display(),
+            bundle_path.display()
+        );
+        project::rec_copy_excl(
+            &build.runnable.source,
+            &bundle_path,
+            false,
+            &[build.runnable.source.join("target")],
+        )?;
+    } else {
+        debug!("Skipping source copy to bundle {}", bundle_path.display());
+    }
+
     debug!("Copying test_data to bundle {}", bundle_path.display());
     project.copy_test_data(&bundle_path)?;
 

--- a/dinghy-lib/src/lib.rs
+++ b/dinghy-lib/src/lib.rs
@@ -305,4 +305,5 @@ pub struct Runnable {
     pub package_name: String,
     pub exe: path::PathBuf,
     pub source: path::PathBuf,
+    pub skip_source_copy: bool,
 }


### PR DESCRIPTION
Dinghy copies all sources to the target device by default, while this this really useful in some cases, this can take some time and some precious space on some small device/huge project combinations.

This adds a `skip_source_copy` flag to the config that will disable this behaviour. The default behaviour stays the same, meaning this should not have any impact on existing setups