### PR TITLE
Disable proc macro tests for tvOS and watchOS

### DIFF
--- a/.travis.apple-third-tier.sh
+++ b/.travis.apple-third-tier.sh
@@ -25,14 +25,17 @@ tests_sequence_unstable_target() {
     # There's something odd with using the .cargo/config runner attribute and
     # workspaces when the runner uses `cargo run --manifest-path ../Cargo.toml
     # --bin cargo-dinghy ...`
+    # TODO 2024/11/18 adding explict `--workspace --exclude test-proc-macro` to the cargo commands here
+    # TODO as a workaround for https://github.com/rust-lang/cargo/issues/14735 this should be removed when the issue
+    # TODO is resolved
     title "testing from project directory for rust target $1 on device $2"
     title "testing from workspace directory"
     ( \
         cd test-ws \
         && cargo clean \
-        && $CARGO_DINGHY   -d $1 -p $2 +nightly test -Zbuild-std pass \
-        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -Zbuild-std fails \
-        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test -Zbuild-std \
+        && $CARGO_DINGHY   -d $1 -p $2 +nightly test --workspace --exclude test-proc-macro -Zbuild-std pass \
+        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test --workspace --exclude test-proc-macro -Zbuild-std fails \
+        && ! $CARGO_DINGHY -d $1 -p $2 +nightly test --workspace --exclude test-proc-macro -Zbuild-std \
     )
 
     title "testing from project directory"


### PR DESCRIPTION
this should fix #238 while we wait for a proper fix for https://github.com/rust-lang/cargo/issues/14735