### PR TITLE
search ndk in default install location in linux

### DIFF
--- a/dinghy-lib/src/android/mod.rs
+++ b/dinghy-lib/src/android/mod.rs
@@ -175,6 +175,10 @@ fn probable_sdk_locs() -> Result<Vec<path::PathBuf>> {
         if mac.is_dir() {
             v.push(mac);
         }
+        let linux = path::Path::new(&home).join("Android/Sdk");
+        if linux.is_dir() {
+            v.push(linux);
+        }
     }
     let casks = path::PathBuf::from("/usr/local/Caskroom/android-sdk");
     if casks.is_dir() {


### PR DESCRIPTION
for some reason we didn't search the default install location of the ndk in linux, this fixes it