### PR TITLE
fix workspace resolver warning in test-ws

### DIFF
--- a/test-ws/Cargo.toml
+++ b/test-ws/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["test-app", "test-proc-macro", "test-bin"]
+resolver = "2"

--- a/test-ws/test-app/Cargo.toml
+++ b/test-ws/test-app/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test-app"
 version = "0.1.0"
 authors = ["Mathieu Poumeyrol <kali@zoy.org>"]
-edition = "2018"
+edition = "2021"
 workspace = "../"
 
 [features]

--- a/test-ws/test-proc-macro/Cargo.toml
+++ b/test-ws/test-proc-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-proc-macro"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 workspace = "../"
 
 [lib]


### PR DESCRIPTION
I also bumped the edition of all the crates in the test workspace to 2021