### PR TITLE
Use VersionReq api to support X.Y versions (needed for iOS 18)

### DIFF
--- a/dinghy-lib/src/apple/device.rs
+++ b/dinghy-lib/src/apple/device.rs
@@ -57,7 +57,7 @@ impl IosDevice {
     }
 
     fn is_pre_ios_17(&self) -> Result<bool> {
-        Ok(semver::Version::parse(&self.os)?.major < 17)
+        Ok(semver::VersionReq::parse(&self.os)?.comparators.get(0).ok_or_else(|| anyhow!("Invalid iOS version: {}", self.os))?.major < 17)
     }
 
     fn is_locked(&self) -> Result<bool> {


### PR DESCRIPTION
iOS 18 versioning has the following format: 18.X. This is not valid when doing Version::parse. This PR use VersionReq to relax this requirement for iOS versioning. 